### PR TITLE
key id from public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # signex
 Sign messages with private key
 
+## Usage
+
+### To sign
+
+```elixir
+private_key = # read private key
+public_key = # read public key
+{:ok, signature, signed_message} = SignEx.sign("my message", private_key, public_key)
+```
+
+### To verify
+
+```elixir
+public_key = # read public key
+case SignEx.verify("my message", signature, public_key) do
+    :ok -> # success
+    {:error, reason} -> # failure
+end
+```
+
 ## How test keys were generated
 
 ### EC

--- a/lib/signex.ex
+++ b/lib/signex.ex
@@ -3,7 +3,7 @@ defmodule SignEx do
   require SignEx.Verifier
   require SignEx.Helper
 
-  def sign(message, private_key), do: SignEx.Signer.sign(message, private_key)
+  def sign(message, private_key, public_key), do: SignEx.Signer.sign(message, private_key, public_key)
   def verify(message, signature, public_key), do: SignEx.Verifier.verify(message, signature, public_key)
   def signature_params(signature), do: SignEx.Helper.signature_params(signature)
 end

--- a/lib/signex/signer.ex
+++ b/lib/signex/signer.ex
@@ -6,46 +6,46 @@ defmodule SignEx.Signer do
     ECPrivateKey: "ec-sha512"
   }
 
-  def sign(message, private_key) do
+  def sign(message, private_key, public_key) do
     message_str = Poison.encode!(message)
-    {:ok, "Signature #{signature_for(%{message: message_str, key: private_key})}", message_str}
+    {:ok, "Signature #{signature_for(%{message: message_str, private_key: private_key, public_key: public_key})}", message_str}
   end
 
-  defp signature_for(%{message: message, key: key}) do
+  defp signature_for(%{message: message, private_key: private_key, public_key: public_key}) do
     salt = generate_salt
     %{
-      key_id: key_id(key),
-      algorithm: algorithm_from_key(key),
+      key_id: key_id(public_key),
+      algorithm: algorithm_from_key(private_key),
       salt: salt,
-      signature: salted_signature(%{message: message, salt: salt, key: key})
+      signature: salted_signature(%{message: message, salt: salt, private_key: private_key})
     }
     |> Enum.map(fn(pair) -> ~s(#{elem(pair, 0)}=#{elem(pair, 1)}) end)
     |> Enum.join(",")
   end
 
-  defp salted_signature(%{message: message, salt: salt, key: key}) do
+  defp salted_signature(%{message: message, salt: salt, private_key: private_key}) do
     hash_message(message, salt)
-    |> sign_message(key)
+    |> sign_message(private_key)
     |> Base.encode64
   end
 
-  defp sign_message(message, key) do
-    :public_key.sign(message, :sha512, decoded_pem_entry(key))
+  defp sign_message(message, private_key) do
+    :public_key.sign(message, :sha512, decoded_pem_entry(private_key))
   end
 
-  defp decoded_pem_entry(key) do
-    decode_pem(key)
+  defp decoded_pem_entry(private_key) do
+    decode_pem(private_key)
     |> :public_key.pem_entry_decode
   end
 
-  defp algorithm_from_key(key) do
-    key_type = decode_pem(key)
+  defp algorithm_from_key(private_key) do
+    key_type = decode_pem(private_key)
     |> elem(0)
     Map.get(@key_types, key_type)
   end
 
-  defp decode_pem(key) do
-    case :public_key.pem_decode(key) do
+  defp decode_pem(private_key) do
+    case :public_key.pem_decode(private_key) do
       [_, key_entry] -> key_entry
       [key_entry] -> key_entry
       key_entry -> raise("unknown key type #{inspect key_entry}")

--- a/test/signex_test.exs
+++ b/test/signex_test.exs
@@ -7,31 +7,32 @@ defmodule Mel.InvoiceApprovedConsumerTest do
   describe "#sign with rsa keys" do
     setup do
       {:ok,
-        private_key: File.read!(Path.expand("../keys/private_key.pem", __ENV__.file))
+        private_key: File.read!(Path.expand("../keys/private_key.pem", __ENV__.file)),
+        public_key: File.read!(Path.expand("../keys/public_key.pem", __ENV__.file))
       }
     end
 
-    test "takes map as message and returns signatures and plaintext version of map", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(@message, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes map as message and returns signatures and plaintext version of map", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(@message, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext, keys: :atoms) == @message
     end
 
-    test "takes string as message and returns signature and encoded plaintext", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(@message_str, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes string as message and returns signature and encoded plaintext", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(@message_str, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext) == @message_str
     end
 
-    test "takes nil as message and returns signature and encoded plaintext", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(nil, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes nil as message and returns signature and encoded plaintext", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(nil, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=rsa-sha512,key_id=37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext) == nil
     end
 
-    test "signatures are different every time for same message", %{private_key: private_key} do
+    test "signatures are different every time for same message", %{private_key: private_key, public_key: public_key} do
       signatures = Enum.reduce([nil, nil, nil, nil], [], fn(msg, result) ->
-        {:ok, signature, _} = SignEx.sign(msg, private_key)
+        {:ok, signature, _} = SignEx.sign(msg, private_key, public_key)
         result ++ [signature]
       end)
       assert Enum.count(Enum.uniq(signatures)) == 4
@@ -41,31 +42,32 @@ defmodule Mel.InvoiceApprovedConsumerTest do
   describe "#sign with ec keys" do
     setup do
       {:ok,
-        private_key: File.read!(Path.expand("../keys/ec_private_key.pem", __ENV__.file))
+        private_key: File.read!(Path.expand("../keys/ec_private_key.pem", __ENV__.file)),
+        public_key: File.read!(Path.expand("../keys/ec_public_key.pem", __ENV__.file))
       }
     end
 
-    test "takes map as message and returns signatures and plaintext version of map", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(@message, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=9d:94:44:7c:7d:fd:b3:3c:63:38:30:b8:fc:c8:de:b1,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes map as message and returns signatures and plaintext version of map", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(@message, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=d8:08:c1:40:74:6f:b7:1e:ff:32:8c:2d:20:b1:b5:04,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext, keys: :atoms) == @message
     end
 
-    test "takes string as message and returns signature and encoded plaintext", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(@message_str, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=9d:94:44:7c:7d:fd:b3:3c:63:38:30:b8:fc:c8:de:b1,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes string as message and returns signature and encoded plaintext", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(@message_str, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=d8:08:c1:40:74:6f:b7:1e:ff:32:8c:2d:20:b1:b5:04,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext) == @message_str
     end
 
-    test "takes nil as message and returns signature and encoded plaintext", %{private_key: private_key} do
-      {:ok, signature, plaintext} = SignEx.sign(nil, private_key)
-      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=9d:94:44:7c:7d:fd:b3:3c:63:38:30:b8:fc:c8:de:b1,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
+    test "takes nil as message and returns signature and encoded plaintext", %{private_key: private_key, public_key: public_key} do
+      {:ok, signature, plaintext} = SignEx.sign(nil, private_key, public_key)
+      assert String.match?(signature, ~r/^Signature algorithm=ec-sha512,key_id=d8:08:c1:40:74:6f:b7:1e:ff:32:8c:2d:20:b1:b5:04,salt=[\w\/\+=]+,signature=[\w\/\+=]+$/)
       assert Poison.decode!(plaintext) == nil
     end
 
-    test "signatures are different every time for same message", %{private_key: private_key} do
+    test "signatures are different every time for same message", %{private_key: private_key, public_key: public_key} do
       signatures = Enum.reduce([nil, nil, nil, nil], [], fn(msg, result) ->
-        {:ok, signature, _} = SignEx.sign(msg, private_key)
+        {:ok, signature, _} = SignEx.sign(msg, private_key, public_key)
         result ++ [signature]
       end)
       assert Enum.count(Enum.uniq(signatures)) == 4
@@ -76,7 +78,7 @@ defmodule Mel.InvoiceApprovedConsumerTest do
     setup do
       {:ok,
         public_key: File.read!(Path.expand("../keys/public_key.pem", __ENV__.file)),
-        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47,salt=KpJtDhiH1gJo/hrdbKmTQC02Vz95RoKUT/JApLIiZm6ueygn6DgXIoE43agrjg2vLrph5ns5860GjymdbnF71w==,signature=en/VJ7zbmnjfQH7f8alFwtoaY9QD3QfmAPTBiK2lUXirA30OJy/nGeVLxgh78G/RATQbL/nQLH3WQP9fq/qe3e5zBtewmH2T0qKkn0qSey5XYe18PtVkd4oJdLzKQZEXnzb1N7BroNM52j/6oRo1NyX9fONC+adUb468IhZOKKoir5FA3wcY1tCZnfORDOWiq1A9yD3QHrr3h4HxthpWr3+WmyiCTYOdbmGRvHnGCdIZmVqQTS1gUhKiq8tg/Ad0G023DaOMmjvy+bD7426A5rvZZvpC2lkvjFYUNUg/KRFVpdLkhtDTxuv5yQDsblhjR2Sz6YuXso0OqK5FJFI7Wg==)
+        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16,salt=KpJtDhiH1gJo/hrdbKmTQC02Vz95RoKUT/JApLIiZm6ueygn6DgXIoE43agrjg2vLrph5ns5860GjymdbnF71w==,signature=en/VJ7zbmnjfQH7f8alFwtoaY9QD3QfmAPTBiK2lUXirA30OJy/nGeVLxgh78G/RATQbL/nQLH3WQP9fq/qe3e5zBtewmH2T0qKkn0qSey5XYe18PtVkd4oJdLzKQZEXnzb1N7BroNM52j/6oRo1NyX9fONC+adUb468IhZOKKoir5FA3wcY1tCZnfORDOWiq1A9yD3QHrr3h4HxthpWr3+WmyiCTYOdbmGRvHnGCdIZmVqQTS1gUhKiq8tg/Ad0G023DaOMmjvy+bD7426A5rvZZvpC2lkvjFYUNUg/KRFVpdLkhtDTxuv5yQDsblhjR2Sz6YuXso0OqK5FJFI7Wg==)
       }
     end
 
@@ -101,7 +103,7 @@ defmodule Mel.InvoiceApprovedConsumerTest do
     setup do
       {:ok,
         public_key: File.read!(Path.expand("../keys/ec_public_key.pem", __ENV__.file)),
-        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=9d:94:44:7c:7d:fd:b3:3c:63:38:30:b8:fc:c8:de:b1,salt=mOUgYm31w5YdicKb1OiCuC3tCxwDhrzTJb18zGRTeXiN789zwC9Q2xbonSsc+ZWMDslsSlgtXieloLhC/UwEwQ==,signature=MIGIAkIBcDizu4+6Bu1cJ863f0KycdaJbwOUby6ynH64fxMhow1emv8ubzGca/sKgDTyN8ijd50FnrwQplWlnmsVjUVjlpoCQgF1OEq9EimaQjErYBKA0ETBKj1hfN5IxfvO8xtQMlUilFBAgjglmF6Yz51aeL+cHcp915p8ckQc0N562L0gehe3gw==)
+        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=d8:08:c1:40:74:6f:b7:1e:ff:32:8c:2d:20:b1:b5:04,salt=mOUgYm31w5YdicKb1OiCuC3tCxwDhrzTJb18zGRTeXiN789zwC9Q2xbonSsc+ZWMDslsSlgtXieloLhC/UwEwQ==,signature=MIGIAkIBcDizu4+6Bu1cJ863f0KycdaJbwOUby6ynH64fxMhow1emv8ubzGca/sKgDTyN8ijd50FnrwQplWlnmsVjUVjlpoCQgF1OEq9EimaQjErYBKA0ETBKj1hfN5IxfvO8xtQMlUilFBAgjglmF6Yz51aeL+cHcp915p8ckQc0N562L0gehe3gw==)
       }
     end
 
@@ -125,7 +127,7 @@ defmodule Mel.InvoiceApprovedConsumerTest do
   describe "#signature_params" do
     setup do
       {:ok,
-        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47,salt=+gF1PZ9f0CkrhyC9dIGbryEMrEF7jlDyqk5Lua7ZAIygrMX9/DR65rdIEolUvZUueovNC4GQ2l+CrIW6dC80zw==,signature=JZKi0BhjBEjgBpU/oIYnowHTG4wym3FWTQXXCe8JWVI2Mw5GMb4tHQ4bI+eqbMRj8InHaYHqrlOtCy4PqtTC36vwrWeN9TjroLUc3Uusu7g8BVIrnR4lC2pXQQOfYPQ5VeQIXIsPI2T97pKtaOVDew2vlezbLn/kuNLI3ffHeTTb30XLpd7urqMI+pLXd1PFD8WGJ4YxG4oltmHWGuya85QXCbbEbJvrmllo3ShReB9flJfQluTXl7UHH3SHjFm5EIqyU4TVcG/phl87+IVYHpHOlLEmlgl0paiKtuWh0IQKknsq9rVVdQ5b9EPN//Az5N66+s7uY7BdaZQZMHBOKg==)
+        test_signature: ~s(Signature algorithm=rsa-sha512,key_id=37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16,salt=+gF1PZ9f0CkrhyC9dIGbryEMrEF7jlDyqk5Lua7ZAIygrMX9/DR65rdIEolUvZUueovNC4GQ2l+CrIW6dC80zw==,signature=JZKi0BhjBEjgBpU/oIYnowHTG4wym3FWTQXXCe8JWVI2Mw5GMb4tHQ4bI+eqbMRj8InHaYHqrlOtCy4PqtTC36vwrWeN9TjroLUc3Uusu7g8BVIrnR4lC2pXQQOfYPQ5VeQIXIsPI2T97pKtaOVDew2vlezbLn/kuNLI3ffHeTTb30XLpd7urqMI+pLXd1PFD8WGJ4YxG4oltmHWGuya85QXCbbEbJvrmllo3ShReB9flJfQluTXl7UHH3SHjFm5EIqyU4TVcG/phl87+IVYHpHOlLEmlgl0paiKtuWh0IQKknsq9rVVdQ5b9EPN//Az5N66+s7uY7BdaZQZMHBOKg==)
       }
     end
 
@@ -133,7 +135,7 @@ defmodule Mel.InvoiceApprovedConsumerTest do
       params = SignEx.signature_params(test_signature)
       assert params == %{
         "algorithm" => "rsa-sha512",
-        "key_id" => "bc:d8:4c:0c:eb:dd:f2:61:4e:f6:da:08:f4:b3:e0:47",
+        "key_id" => "37:5c:69:cd:45:2b:4e:f9:77:5f:67:75:88:38:b2:16",
         "salt" => "+gF1PZ9f0CkrhyC9dIGbryEMrEF7jlDyqk5Lua7ZAIygrMX9/DR65rdIEolUvZUueovNC4GQ2l+CrIW6dC80zw==",
         "signature" => "JZKi0BhjBEjgBpU/oIYnowHTG4wym3FWTQXXCe8JWVI2Mw5GMb4tHQ4bI+eqbMRj8InHaYHqrlOtCy4PqtTC36vwrWeN9TjroLUc3Uusu7g8BVIrnR4lC2pXQQOfYPQ5VeQIXIsPI2T97pKtaOVDew2vlezbLn/kuNLI3ffHeTTb30XLpd7urqMI+pLXd1PFD8WGJ4YxG4oltmHWGuya85QXCbbEbJvrmllo3ShReB9flJfQluTXl7UHH3SHjFm5EIqyU4TVcG/phl87+IVYHpHOlLEmlgl0paiKtuWh0IQKknsq9rVVdQ5b9EPN//Az5N66+s7uY7BdaZQZMHBOKg=="
       }


### PR DESCRIPTION
Message signing requires private and public key. So `key_id` in signature is key id of public key not private key as it is how "other" side can locate public key.